### PR TITLE
fix connnection leak with primary server

### DIFF
--- a/repmgrd-physical.c
+++ b/repmgrd-physical.c
@@ -533,6 +533,7 @@ monitor_streaming_primary(void)
 
 			if (is_server_available(local_node_info.conninfo) == true)
 			{
+				close_connection(&local_conn);
 				local_conn = establish_db_connection(local_node_info.conninfo, false);
 
 				if (PQstatus(local_conn) != CONNECTION_OK)
@@ -1761,7 +1762,10 @@ monitor_streaming_standby(void)
 			if (upstream_check_result == true)
 			{
 				if (config_file_options.connection_check_type != CHECK_QUERY)
+				{
+					close_connection(&upstream_conn);
 					upstream_conn = establish_db_connection(upstream_node_info.conninfo, false);
+				}
 
 				if (PQstatus(upstream_conn) == CONNECTION_OK)
 				{
@@ -2489,8 +2493,10 @@ monitor_streaming_witness(void)
 			if (check_upstream_connection(&primary_conn, upstream_node_info.conninfo, NULL) == true)
 			{
 				if (config_file_options.connection_check_type != CHECK_QUERY)
+				{
+					close_connection(&primary_conn);
 					primary_conn = establish_db_connection(upstream_node_info.conninfo, false);
-
+				}
 				if (PQstatus(primary_conn) == CONNECTION_OK)
 				{
 					PQExpBufferData event_details;


### PR DESCRIPTION
when recover from degraded state, repmgr will make two connections to primary server and lost one connection reference.
