### PR TITLE
Doc: Update or remove references to recovery.conf

### DIFF
--- a/doc/appendix-faq.xml
+++ b/doc/appendix-faq.xml
@@ -249,16 +249,16 @@
         For a standby which has been manually cloned or recovered from an external
         backup manager such as Barman, the command
         <command><link linkend="repmgr-standby-clone">repmgr standby clone --replication-conf-only</link></command>
-        can be used to create the correct <filename>recovery.conf</filename> file for
+        can be used to create the correct replication configuration file for
         use with &repmgr; (and will create a replication slot if required). Once this has been done,
         <link linkend="repmgr-standby-register">register the node</link> as usual.
       </para>
     </sect2>
 
     <sect2 id="faq-repmgr-recovery-conf" >
-      <title>What does &repmgr; write in <filename>recovery.conf</filename>, and what options can be set there?</title>
+      <title>What does &repmgr; write in the replication configuration, and what options can be set there?</title>
       <para>
-        See section <link linkend="repmgr-standby-clone-recovery-conf">Customising recovery.conf</link>.
+        See section <link linkend="repmgr-standby-clone-recovery-conf">Customising replication configuration</link>.
       </para>
     </sect2>
 
@@ -366,11 +366,11 @@
       </para>
     </sect2>
 
-    <sect2 id="faq-repmgr-recovery-conf-quoted-values" xreflabel="Quoted values in recovery.conf">
-      <title>Why are some values in <filename>recovery.conf</filename> surrounded by pairs of single quotes?</title>
+    <sect2 id="faq-repmgr-recovery-conf-quoted-values" xreflabel="Quoted values in replication configuration">
+      <title>Why are some values in the replication configuration file surrounded by pairs of single quotes?</title>
       <para>
-        This is to ensure that user-supplied values which are written as parameter values in <filename>recovery.conf</filename>
-        are escaped correctly and do not cause errors when <filename>recovery.conf</filename> is parsed.
+        This is to ensure that user-supplied values which are written as parameter values in the replication configuration
+        are escaped correctly and do not cause errors when the file is parsed.
       </para>
       <para>
         The escaping is performed by an internal PostgreSQL routine, which leaves strings consisting
@@ -419,7 +419,7 @@
       <para>
         &repmgrd; can monitor delayed standbys - those set up with
         <varname>recovery_min_apply_delay</varname> set to a non-zero value
-        in <filename>recovery.conf</filename> - but as it's not currently possible
+        in the replication configuration - but as it's not currently possible
         to directly examine the value applied to the standby, &repmgrd;
         may not be able to properly evaluate the node as a promotion candidate.
       </para>

--- a/doc/cloning-standbys.xml
+++ b/doc/cloning-standbys.xml
@@ -197,7 +197,7 @@ description = "Main cluster"
    <para>
     As a fallback in case streaming replication is interrupted, PostgreSQL can optionally
     retrieve WAL files from an archive, such as that provided by Barman. This is done by
-    setting <varname>restore_command</varname> in <filename>recovery.conf</filename> to
+    setting <varname>restore_command</varname> in the replication configuration to
     a valid shell command which can retrieve a specified WAL file from the archive.
    </para>
    <para>
@@ -328,9 +328,9 @@ description = "Main cluster"
     &repmgr; supports cascading replication. When cloning a standby,
     set the command-line parameter <literal>--upstream-node-id</literal> to the
     <varname>node_id</varname> of the server the standby should connect to, and
-    &repmgr; will create <filename>recovery.conf</filename> to point to it. Note
+    &repmgr; will create a replication configuration file to point to it. Note
     that if <literal>--upstream-node-id</literal> is not explicitly provided,
-    &repmgr; will set the standby's <filename>recovery.conf</filename> to
+    &repmgr; will set the standby's replication configuration to
     point to the primary node.
    </para>
    <para>
@@ -392,7 +392,7 @@ description = "Main cluster"
      does not yet exist. In this case you can clone from the primary (or
      another upstream node); provide the parameter <literal>--upstream-conninfo</literal>
      to explicitly set the upstream's <varname>primary_conninfo</varname> string
-     in <filename>recovery.conf</filename>.
+     in the replication configuration.
     </simpara>
    </tip>
  </sect1>
@@ -491,12 +491,12 @@ description = "Main cluster"
     </note>
 
     <para>
-     If, for whatever reason, you wish to include the password in <filename>recovery.conf</filename>,
+     If, for whatever reason, you wish to include the password in the replication configuration file,
      set <varname>use_primary_conninfo_password</varname> to <literal>true</literal> in
      <filename>repmgr.conf</filename>. This will read a password set in <varname>PGPASSWORD</varname>
      (but not <filename>~/.pgpass</filename>) and place it into the <varname>primary_conninfo</varname>
-     string in <filename>recovery.conf</filename>. Note that <varname>PGPASSWORD</varname>
-     will need to be set during any action which causes <filename>recovery.conf</filename> to be
+     string in the replication configuration. Note that <varname>PGPASSWORD</varname>
+     will need to be set during any action which causes the replication configuration file to be
      rewritten, e.g. <xref linkend="repmgr-standby-follow"/>.
     </para>
    </sect2>
@@ -508,7 +508,7 @@ description = "Main cluster"
      user (in addition to the user who manages the &repmgr; metadata). In this case,
      the replication user should be set in <filename>repmgr.conf</filename> via the parameter
      <varname>replication_user</varname>; &repmgr; will use this value when making
-     replication connections and generating <filename>recovery.conf</filename>. This
+     replication connections and generating the replication configuration. This
      value will also be stored in the parameter <literal>repmgr.nodes</literal>
      table for each node; it no longer needs to be explicitly specified when
      cloning a node or executing <xref linkend="repmgr-standby-follow"/>.

--- a/doc/quickstart.xml
+++ b/doc/quickstart.xml
@@ -405,9 +405,9 @@
   </programlisting>
   <para>
    This has cloned the PostgreSQL data directory files from the primary <literal>node1</literal>
-   using PostgreSQL's <command>pg_basebackup</command> utility. A <filename>recovery.conf</filename>
-   file containing the correct parameters to start streaming from this primary server will be created
-   automatically.
+   using PostgreSQL's <command>pg_basebackup</command> utility. A <filename>postgresql.auto.conf</filename>
+   (PostgreSQL 11 and earlier: <filename>recovery.conf</filename>) file containing the correct
+   parameters to start streaming from this primary server will be created automatically.
   </para>
   <note>
    <simpara>
@@ -481,9 +481,10 @@
     sender_port           | 5432
     conninfo              | user=repmgr dbname=replication host=node1 application_name=node2
    </programlisting>
-   Note that the <varname>conninfo</varname> value is that generated in <filename>recovery.conf</filename>
-   and will differ slightly from the primary's <varname>conninfo</varname> as set in <filename>repmgr.conf</filename> -
-   among others it will contain the connecting node's name as <varname>application_name</varname>.
+   Note that the <varname>conninfo</varname> value is that generated in <filename>postgresql.auto.conf</filename>
+   (PostgreSQL 11 and earlier: <filename>recovery.conf</filename>) and will differ slightly from the primary's
+   <varname>conninfo</varname> as set in <filename>repmgr.conf</filename> - among others it will contain the
+   connecting node's name as <varname>application_name</varname>.
   </para>
  </sect1>
 


### PR DESCRIPTION
As the [release notes for repmgr 5.0](https://repmgr.org/docs/5.0/release-5.0.html) say:

> Beginning with PostgreSQL 12, replication configuration has been integrated into the main PostgreSQL configuraton system and the conventional `recovery.conf` file is no longer valid.
> 
> repmgr has been modified to be compatible with this change.

However, the docs still used to contain some references to the file. This PR removes them and adds an explaining distinction where appropriate.