### PR TITLE
repmgrd: reload witness local info after copy node record from primary

### DIFF
--- a/repmgrd-physical.c
+++ b/repmgrd-physical.c
@@ -2381,7 +2381,17 @@ monitor_streaming_witness(void)
 		{
 			log_warning(_("unable to retrieve node record from primary"));
 		}
+		/* refresh record for this node from the local database */
+		record_status = get_node_record(local_conn, config_file_options.node_id, &local_node_info);
 
+		if (record_status != RECORD_FOUND)
+		{
+			log_error(_("no metadata record found for this node - terminating"));
+			log_hint(_("execute \"ltcluster witness register --force\" to sync the local node records"));
+			close_connection(&primary_conn);
+			close_connection(&local_conn);
+			terminate(ERR_BAD_CONFIG);
+		}
 		initPQExpBuffer(&event_details);
 
 		appendPQExpBuffer(&event_details,


### PR DESCRIPTION
witness record in primary may different from witness.

for example:

 1. stop witness database : pg_ctl stop 
 2. witness repmgrd modify primary database node : active=false 
 3. stop witness repmgrd 
 4. start wtiness database 
 5. start witness repmgrd 
 
in step 5:  repmgrd load local database with active=true; and then copy node records from primary(active=false)