### PR TITLE
Adding flex and libs as deps

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -60,6 +60,7 @@ AC_SUBST(vpath_build)
 AC_CHECK_PROG(HAVE_GNUSED,gnused,yes,no)
 AC_CHECK_PROG(HAVE_GSED,gsed,yes,no)
 AC_CHECK_PROG(HAVE_SED,sed,yes,no)
+AC_CHECK_PROG(HAVE_FLEX,flex,yes,no)
 
 if test "$HAVE_GNUSED" = yes; then
  SED=gnused
@@ -72,6 +73,7 @@ else
 fi
 AC_SUBST(SED)
 
+AS_IF([test x"$HAVE_FLEX" != x"yes"], AC_MSG_ERROR([flex should be installed first]))
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([Makefile.global])

--- a/configure.in
+++ b/configure.in
@@ -75,6 +75,24 @@ AC_SUBST(SED)
 
 AS_IF([test x"$HAVE_FLEX" != x"yes"], AC_MSG_ERROR([flex should be installed first]))
 
+#Checking libraries
+GENERIC_LIB_FAILED_MSG="library should be installed"
+
+AC_CHECK_LIB(selinux, is_selinux_enabled, [],
+     [AC_MSG_ERROR(['selinux' $GENERIC_LIB_FAILED_MSG])])
+
+AC_CHECK_LIB(lz4, LZ4_compress_default, [],
+     [AC_MSG_ERROR(['Z4' $GENERIC_LIB_FAILED_MSG])])
+
+AC_CHECK_LIB(xslt, xsltCleanupGlobals, [],
+     [AC_MSG_ERROR(['xslt' $GENERIC_LIB_FAILED_MSG])])
+
+AC_CHECK_LIB(pam, pam_start, [],
+     [AC_MSG_ERROR(['pam' $GENERIC_LIB_FAILED_MSG])])
+
+AC_CHECK_LIB(gssapi_krb5, gss_init_sec_context, [],
+     [AC_MSG_ERROR([gssapi_krb5 $GENERIC_LIB_FAILED_MSG])])
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([Makefile.global])
 AC_OUTPUT


### PR DESCRIPTION
If the required libraries are not installed, all the errors will be caught when gcc is compilling[1] and after `configure` wrapped everything up. I believe we could improve the process just a bit by checking for flex and other required libraries inside this step and before gcc. At least this is what usually happen when someone needs to compile a repo with autotools... tools :-)

Tested with autoconf v2.71. I haven't included the resulting `configure` file because it's going to be a large chunk and not sure if we could bump to that version.

[1] Example of how this looks without flex:
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer -fPIC -std=gnu89 -I/usr/include/postgresql/internal -I/usr/include/postgresql -Wall -Wmissing-prototypes -Wmissing-declarations  -I. -I./ -I/usr/include/postgresql/14/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2   -c -o configfile.o configfile.c
flex  -o'configfile-scan.c' configfile-scan.l
make: flex: No such file or directory
make: *** [Makefile.global:40: configfile-scan.c] Error 127