### PR TITLE
Add 'cluster status' alias for consistency

### DIFF
--- a/repmgr-action-cluster.c
+++ b/repmgr-action-cluster.c
@@ -1499,6 +1499,7 @@ do_cluster_help(void)
 
 	printf(_("Usage:\n"));
 	printf(_("    %s [OPTIONS] cluster show\n"), progname());
+	printf(_("    %s [OPTIONS] cluster status\n"), progname());
 	printf(_("    %s [OPTIONS] cluster matrix\n"), progname());
 	printf(_("    %s [OPTIONS] cluster crosscheck\n"), progname());
 	printf(_("    %s [OPTIONS] cluster event\n"), progname());
@@ -1513,6 +1514,11 @@ do_cluster_help(void)
 	puts("");
 	printf(_("    --csv                     emit output as CSV (with a subset of fields)\n"));
 	printf(_("    --compact                 display only a subset of fields\n"));
+	puts("");
+
+	printf(_("CLUSTER STATUS\n"));
+	puts("");
+	printf(_("  \"cluster status\" is an alias to \"cluster show\".\n"));
 	puts("");
 
 	printf(_("CLUSTER MATRIX\n"));

--- a/repmgr-client.c
+++ b/repmgr-client.c
@@ -962,6 +962,9 @@ main(int argc, char **argv)
 
 			if (strcasecmp(repmgr_action, "SHOW") == 0)
 				action = CLUSTER_SHOW;
+			/* alias to SHOW */
+			else if (strcasecmp(repmgr_action, "STATUS") == 0)
+				action = CLUSTER_SHOW;
 			else if (strcasecmp(repmgr_action, "EVENT") == 0)
 				action = CLUSTER_EVENT;
 			/* allow "CLUSTER EVENTS" as synonym for "CLUSTER EVENT" */
@@ -2678,7 +2681,7 @@ do_help(void)
 	printf(_("    %s [OPTIONS] primary {register|unregister}\n"), progname());
 	printf(_("    %s [OPTIONS] standby {register|unregister|clone|promote|follow|switchover}\n"), progname());
 	printf(_("    %s [OPTIONS] node    {status|check|rejoin|service}\n"), progname());
-	printf(_("    %s [OPTIONS] cluster {show|event|matrix|crosscheck|cleanup}\n"), progname());
+	printf(_("    %s [OPTIONS] cluster {show|status|event|matrix|crosscheck|cleanup}\n"), progname());
 	printf(_("    %s [OPTIONS] witness {register|unregister}\n"), progname());
 	printf(_("    %s [OPTIONS] service {status|pause|unpause}\n"), progname());
 	printf(_("    %s [OPTIONS] daemon  {start|stop}\n"), progname());


### PR DESCRIPTION
I propose adding a `cluster status` action that is an alias to `cluster show`. This is consistent with other actions such as `node status` and `service status`.