### PR TITLE
Validate repmgr options

### DIFF
--- a/pgbackupapi.c
+++ b/pgbackupapi.c
@@ -50,7 +50,7 @@ size_t receive_operations_cb(void *content, size_t size, size_t nmemb, char *buf
 }
 
 char * define_base_url(operation_task *task) {
-	char *format = "http://%s:80/servers/%s/operations";
+	char *format = "http://%s:7480/servers/%s/operations";
 	char *url = malloc(MAX_BUFFER_LENGTH);
 
 	snprintf(url, MAX_BUFFER_LENGTH-1, format, task->host, task->node_name);

--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -7795,6 +7795,7 @@ run_pg_backupapi(t_node_info *local_node_record)
 	CURL *curl = curl_easy_init();
 	CURLcode ret;
 
+	check_pg_backupapi_standby_clone_options();
 
 	task->host = malloc(strlen(config_file_options.pg_backupapi_host)+1);
 	task->remote_ssh_command = malloc(strlen(config_file_options.pg_backupapi_remote_ssh_command)+1);
@@ -7857,6 +7858,36 @@ run_pg_backupapi(t_node_info *local_node_record)
 	free(task);
 	return r;
 }
+
+/*
+ * pg_backupapi mode is enabled when config_file_options.pg_backupapi_host is set hence, we
+ * should also check the other required variables too.
+ */
+
+void check_pg_backupapi_standby_clone_options() {
+
+	bool error = false;
+
+	if (*config_file_options.pg_backupapi_remote_ssh_command == '\0') {
+		log_hint("Check config: remote ssh command is required");
+		error = true;
+	}
+	if (*config_file_options.pg_backupapi_node_name == '\0') {
+		log_hint("Check config: node name is required");
+		error = true;
+	}
+	if (*config_file_options.pg_backupapi_backup_id == '\0') {
+		log_hint("Check config: backup_id is required");
+		error = true;
+	}
+
+	if (error == true) {
+		log_error("Please fix the errors and try again");
+		exit(ERR_BAD_CONFIG);
+	}
+
+}
+
 
 
 static char *

--- a/repmgr-action-standby.h
+++ b/repmgr-action-standby.h
@@ -30,6 +30,6 @@ extern void do_standby_help(void);
 
 extern bool do_standby_follow_internal(PGconn *primary_conn, PGconn *follow_target_conn, t_node_info *follow_target_node_record, PQExpBufferData *output, int general_error_code, int *error_code);
 
-
+void check_pg_backupapi_standby_clone_options(void);
 
 #endif							/* _REPMGR_ACTION_STANDBY_H_ */


### PR DESCRIPTION
we need to use 7480 instead of 80 by default. And validate the rest of pg-backup-api options when that mode is enabled.