### PR TITLE
Added check for wal_retrieve_retry_interval parameter ALTER SYSTEM privilege presence

### DIFF
--- a/dbutils.c
+++ b/dbutils.c
@@ -1922,14 +1922,14 @@ can_disable_walsender(PGconn *conn)
 	{
 		initPQExpBuffer(&query);
 		appendPQExpBufferStr(&query,
-							" SELECT pg_catalog.has_parameter_privilege('wal_retrieve_retry_interval', 'ALTER SYSTEM') ");
+						" SELECT pg_catalog.has_parameter_privilege('wal_retrieve_retry_interval', 'ALTER SYSTEM') ");
 
 		res = PQexec(conn, query.data);
 
 		if (PQresultStatus(res) != PGRES_TUPLES_OK)
 		{
 			log_db_error(conn, query.data,
-						_("can_disable_walsender(): unable to query user parameter privileges"));
+					_("can_disable_walsender(): unable to query user parameter privileges"));
 		}
 		else
 		{

--- a/dbutils.c
+++ b/dbutils.c
@@ -1941,16 +1941,16 @@ can_disable_walsender(PGconn *conn)
 
 	if (has_alter_system_priv == false)
 	{
-		log_warning(_("\"standby_disconnect_on_failover\" specified, but repmgr user is not authorized to ALTER SYSTEM"));
+		log_warning(_("\"standby_disconnect_on_failover\" specified, but repmgr user is not authorized to perform ALTER SYSTEM wal_retrieve_retry_interval"));
 
 		if (PQserverVersion(conn) >= 150000)
-        {
-            log_detail(_("superuser or ALTER SYSTEM wal_retrieve_retry_interval permission required to disable standbys on failover"));
-        }
-        else
-        {
-            log_detail(_("superuser permission required to disable standbys on failover"));
-        }
+		{
+			log_detail(_("superuser or ALTER SYSTEM wal_retrieve_retry_interval permission required to disable standbys on failover"));
+		}
+		else
+		{
+			log_detail(_("superuser permission required to disable standbys on failover"));
+		}
 	}
 
 	return has_alter_system_priv;

--- a/dbutils.c
+++ b/dbutils.c
@@ -1913,15 +1913,47 @@ can_disable_walsender(PGconn *conn)
 	if (is_superuser_connection(conn, NULL) == true)
 		return true;
 
-	/*
-	 * As of PostgreSQL 14, it is not possible for a non-superuser
-	 * to execute ALTER SYSTEM, so further checks are superfluous.
-	 * This will need modifying for PostgreSQL 15.
-	 */
-	log_warning(_("\"standby_disconnect_on_failover\" specified, but repmgr user is not a superuser"));
-	log_detail(_("superuser permission required to disable standbys on failover"));
+	PQExpBufferData query;
+	PGresult   *res;
+	bool		has_alter_system_priv = false;
 
-	return false;
+	/* GRANT ALTER SYSTEM available from PostgreSQL 15 */
+	if (PQserverVersion(conn) >= 150000)
+	{
+		initPQExpBuffer(&query);
+		appendPQExpBufferStr(&query,
+							" SELECT pg_catalog.has_parameter_privilege('wal_retrieve_retry_interval', 'ALTER SYSTEM') ");
+
+		res = PQexec(conn, query.data);
+
+		if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		{
+			log_db_error(conn, query.data,
+						_("can_disable_walsender(): unable to query user parameter privileges"));
+		}
+		else
+		{
+			has_alter_system_priv = atobool(PQgetvalue(res, 0, 0));
+		}
+		termPQExpBuffer(&query);
+		PQclear(res);
+	}
+
+	if (has_alter_system_priv == false)
+	{
+		log_warning(_("\"standby_disconnect_on_failover\" specified, but repmgr user is not authorized to ALTER SYSTEM"));
+
+		if (PQserverVersion(conn) >= 150000)
+        {
+            log_detail(_("superuser or ALTER SYSTEM wal_retrieve_retry_interval permission required to disable standbys on failover"));
+        }
+        else
+        {
+            log_detail(_("superuser permission required to disable standbys on failover"));
+        }
+	}
+
+	return has_alter_system_priv;
 }
 
 /*

--- a/doc/configuration-permissions.xml
+++ b/doc/configuration-permissions.xml
@@ -161,6 +161,8 @@
               <varname>standby_disconnect_on_failover</varname> is set to <literal>true</literal> in
               <filename>repmgr.conf</filename>. <command>ALTER SYSTEM</command> can only be executed by
               a superuser; if the &repmgr; user is not a superuser, this functionality will not be available.
+              From PostgreSQL 15 ALTER SYSTEM privilege for specific settings can be granted with e.g.
+              <command>GRANT ALTER SYSTEM ON PARAMETER wal_retrieve_retry_interval TO repmgr</command>.
             </simpara>
           </listitem>
         </itemizedlist>

--- a/doc/configuration-permissions.xml
+++ b/doc/configuration-permissions.xml
@@ -159,9 +159,9 @@
             <simpara>
               The <command>ALTER SYSTEM</command> is executed by &repmgrd; if
               <varname>standby_disconnect_on_failover</varname> is set to <literal>true</literal> in
-              <filename>repmgr.conf</filename>. <command>ALTER SYSTEM</command> can only be executed by
+              <filename>repmgr.conf</filename>. Until PostgreSQL 14 <command>ALTER SYSTEM</command> can only be executed by
               a superuser; if the &repmgr; user is not a superuser, this functionality will not be available.
-              From PostgreSQL 15 ALTER SYSTEM privilege for specific settings can be granted with e.g.
+              From PostgreSQL 15 a specific ALTER SYSTEM privilege can be granted with e.g.
               <command>GRANT ALTER SYSTEM ON PARAMETER wal_retrieve_retry_interval TO repmgr</command>.
             </simpara>
           </listitem>

--- a/doc/repmgrd-automatic-failover.xml
+++ b/doc/repmgrd-automatic-failover.xml
@@ -279,9 +279,9 @@
   <note>
     <para>
       <option>standby_disconnect_on_failover</option> is available with PostgreSQL 9.5 and later.
-      Additionally this requires that the <literal>repmgr</literal> database user is a superuser.
-      From PostgreSQL 15 ALTER SYSTEM privilege for specific settings can be granted with
-      e.g. <command>GRANT ALTER SYSTEM ON PARAMETER wal_retrieve_retry_interval TO repmgr</command>.
+      Until PostgreSQL 14 this requires that the <literal>repmgr</literal> database user is a superuser.
+      From PostgreSQL 15 a specific ALTER SYSTEM privilege can be granted to the <literal>repmgr</literal> database
+      user with e.g. <command>GRANT ALTER SYSTEM ON PARAMETER wal_retrieve_retry_interval TO repmgr</command>.
     </para>
   </note>
   <para>

--- a/doc/repmgrd-automatic-failover.xml
+++ b/doc/repmgrd-automatic-failover.xml
@@ -280,6 +280,8 @@
     <para>
       <option>standby_disconnect_on_failover</option> is available with PostgreSQL 9.5 and later.
       Additionally this requires that the <literal>repmgr</literal> database user is a superuser.
+      From PostgreSQL 15 ALTER SYSTEM privilege for specific settings can be granted with
+      e.g. <command>GRANT ALTER SYSTEM ON PARAMETER wal_retrieve_retry_interval TO repmgr</command>.
     </para>
   </note>
   <para>

--- a/repmgr.conf.sample
+++ b/repmgr.conf.sample
@@ -340,7 +340,9 @@ ssh_options='-q -o ConnectTimeout=10'	# Options to append to "ssh"
 #repmgrd_exit_on_inactive_node=false	# If "true", and the node record is marked as "inactive", abort repmgrd startup
 #standby_disconnect_on_failover=false	# If "true", in a failover situation wait for all standbys to
 					# disconnect their WAL receivers before electing a new primary
-					# (PostgreSQL 9.5 and later only; repmgr user must be a superuser for this)
+					# Can be true in PostgreSQL 9.5 and later only. Until PostgreSQL 14 repmgr user must be a superuser to use this.
+					# From PostgreSQL 15 repmgr must be a superuser or have 'ALTER SYSTEM wal_retrieve_retry_interval' privilege.
+					# (see: https://repmgr.org/docs/current/repmgrd-standby-disconnection-on-failover.html )
 #sibling_nodes_disconnect_timeout=30	# If "standby_disconnect_on_failover" is true, the maximum length of time
 					#  (in seconds) to wait for other standbys to confirm they have disconnected their
 					# WAL receivers


### PR DESCRIPTION
The Repmgr **standby_disconnect_on_failover** option requires to edit permanently (**ALTER SYSTEM** privilege) **wal_retrieve_retry_interval** system parameter, privilege reserved to superusers only until PostgreSQL 14.

From PostgreSQL 15 it is changed, as reported on [v15 changelog](https://www.postgresql.org/docs/release/15.0/):

> Allow [GRANT](https://www.postgresql.org/docs/15/sql-grant.html) to grant permissions to change individual server variables via SET and ALTER SYSTEM (Mark Dilger)
> 
> The new function [has_parameter_privilege()](https://www.postgresql.org/docs/15/functions-info.html) reports on this privilege.

This PR add the check of **wal_retrieve_retry_interval** parameter change privilege via **ALTER SYSTEM** if **repmgr** database user is not a superuser.
