### PR TITLE
Adding Postgres version 16 support in 5.4.1

### DIFF
--- a/doc/appendix-release-notes.xml
+++ b/doc/appendix-release-notes.xml
@@ -18,9 +18,9 @@
   <!-- remember to update the release date in ../repmgr_version.h.in -->
   <sect1 id="release-5.4.1">
     <title id="release-current">Release 5.4.1</title>
-    <para><emphasis>??? ?? ??????, 202?</emphasis></para>
+    <para><emphasis>Tue 04 July, 2023</emphasis></para>
     <para>
-      &repmgr; 5.4.1 is a minor release providing ...
+      &repmgr; 5.4.1 is a minor release providing a fix for witness metadata update
     </para>
     <sect2>
       <title>Bug fixes</title>

--- a/doc/install-requirements.xml
+++ b/doc/install-requirements.xml
@@ -120,13 +120,13 @@
               &repmgr; 5.4
             </entry>
             <entry>
-              (dev)
+              YES
             </entry>
             <entry>
               <link linkend="release-current">&repmgrversion;</link> (&releasedate;)
             </entry>
             <entry>
-              9.4, 9.5, 9.6, 10, 11, 12, 13, 15
+              10, 11, 12, 13, 14, 15, 16
             </entry>
             <entry>
               &nbsp;

--- a/doc/install-requirements.xml
+++ b/doc/install-requirements.xml
@@ -14,7 +14,7 @@
   </para>
 
   <para>
-   &repmgr; &repmgrversion; is compatible with all PostgreSQL versions from 9.4. See
+   &repmgr; &repmgrversion; is compatible with all PostgreSQL versions from 10. See
    section <link linkend="install-compatibility-matrix">&repmgr; compatibility matrix</link>
    for an overview of version compatibility.
   </para>

--- a/doc/repmgr.xml
+++ b/doc/repmgr.xml
@@ -26,7 +26,7 @@
   <abstract>
    <para>
    This is the official documentation of &repmgr; &repmgrversion; for
-   use with PostgreSQL 9.4 - PostgreSQL 15.
+   use with PostgreSQL 9.4 - PostgreSQL 16.
    </para>
    <para>
      &repmgr; is being continually developed and we strongly recommend using the

--- a/doc/repmgr.xml
+++ b/doc/repmgr.xml
@@ -26,7 +26,7 @@
   <abstract>
    <para>
    This is the official documentation of &repmgr; &repmgrversion; for
-   use with PostgreSQL 9.4 - PostgreSQL 16.
+   use with PostgreSQL 10 - PostgreSQL 16.
    </para>
    <para>
      &repmgr; is being continually developed and we strongly recommend using the


### PR DESCRIPTION
We've done extensive testing of the current version of repmgr against the new version 16 of Postgres. The tests have passed which gives us the green light to add the version as supported in repmgr 5.4.1.

The commit only addresses documentation amendments