### PR TITLE
Check for USAGE (instead of MEMBER) privilege in all pg_has_role occurrences

### DIFF
--- a/dbutils.c
+++ b/dbutils.c
@@ -1979,13 +1979,13 @@ connection_has_pg_monitor_role(PGconn *conn, const char *subrole)
 	initPQExpBuffer(&query);
 	appendPQExpBufferStr(&query,
 						 "  SELECT CASE "
-						 "           WHEN pg_catalog.pg_has_role('pg_monitor','MEMBER') "
+						 "           WHEN pg_catalog.pg_has_role('pg_monitor','USAGE') "
 						 "             THEN TRUE ");
 
 	if (subrole != NULL)
 	{
 		appendPQExpBuffer(&query,
-						  "           WHEN pg_catalog.pg_has_role('%s','MEMBER') "
+						  "           WHEN pg_catalog.pg_has_role('%s','USAGE') "
 						  "             THEN TRUE ",
 						  subrole);
 	}


### PR DESCRIPTION
To work correctly Repmgr database user should be included in some roles ad this is checked by `pg_has_role` function.
In all `pg_has_role` functions `MEMBER` privilege is checked but in Repmgr code no `SET ROLE` is present so it better to check in `pg_has_role` functions `USAGE` privilege instead (that includes `INHERIT` check).

`pg_has_role` function documentation: https://www.postgresql.org/docs/16/functions-info.html#id-1.5.8.32.4.4.2.2.14.1.1.1

PR already discussed with @martinmarques here: https://github.com/EnterpriseDB/repmgr/pull/807#discussion_r1750197750