### PR TITLE
Fix wrong reference to connection from commit f69485c0

### DIFF
--- a/repmgr-action-standby.c
+++ b/repmgr-action-standby.c
@@ -5299,7 +5299,7 @@ do_standby_switchover(void)
 		{
 			log_warning(_("no authorized connection available, unable to issue CHECKPOINT"));
 
-			if (PQserverVersion(conn) >= 150000)
+			if (PQserverVersion(local_conn) >= 150000)
 			{
 				log_hint(_("provide a superuser with -S/--superuser or grant pg_checkpoint role to repmgr user"));
 			}


### PR DESCRIPTION
Commit f69485c0 introduced a change in how we check if the repmgr user can run checkpoints on PG15 and newer.

There was a regression in the messages where the conn passed was not declared. That is because the pointer we were using was called checkpoint_conn instead of conn.