### PR TITLE
install-requirements.xml: fix compatibility matrix

### DIFF
--- a/doc/install-requirements.xml
+++ b/doc/install-requirements.xml
@@ -125,7 +125,7 @@
               <link linkend="release-5.5.0">&repmgrversion;</link> (&releasedate;)
             </entry>
             <entry>
-              12, 13, 15, 16, 17
+              13, 14, 15, 16, 17
             </entry>
             <entry>
               &nbsp;
@@ -143,7 +143,7 @@
               <link linkend="release-5.4.1">5.4.1</link> (2023-04-04)
             </entry>
             <entry>
-              10, 11, 12, 13, 15
+              10, 11, 12, 13, 14, 15
             </entry>
             <entry>
               &nbsp;


### PR DESCRIPTION
The same document states that "repmgr 5.5.0 is compatible with all supported PostgreSQL versions from 13.x", so 12 shouldn't be listed in the matrix.

Moreover, 14 is missing in 5.5 and 5.4.1, which looks like an accidental omission that might have happened when support for 15 was added on a version that only advertized 13 up to that point. 14 should have been added along with 15 then.